### PR TITLE
Upgrade OrderedSet to add privacy manifest

### DIFF
--- a/flutter_inappwebview_ios/ios/flutter_inappwebview_ios.podspec
+++ b/flutter_inappwebview_ios/ios/flutter_inappwebview_ios.podspec
@@ -31,7 +31,7 @@ A new Flutter plugin.
   s.swift_version = '5.0'
 
   s.platforms = { :ios => '11.0' }
-  s.dependency 'OrderedSet', '~>5.0'
+  s.dependency 'OrderedSet', '~>6.0'
 
   s.default_subspec = 'Core'
 


### PR DESCRIPTION
In addition to https://github.com/pichillilorenzo/flutter_inappwebview/pull/2029, this PR upgrades `OrderedSet` as well to add privacy manifest to it.

`OrderedSet` is on the list: https://developer.apple.com/support/third-party-SDK-requirements/

Once this is merged, https://github.com/pichillilorenzo/flutter_inappwebview/pull/2029 should also include this change which points to the main stream.


NOTE: I chose this fork over the other one just because it was easier for us to install using `dependency_overrides`.